### PR TITLE
Enable `lto` for `release` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ default-members = ["plastic_ui"]
 opt-level = 2
 
 [profile.release]
+lto = true
 opt-level = 3
 
 [profile.ci]


### PR DESCRIPTION
Fixes #10

This was removed in fe271ee10aa80c92b91f3f9f7967e56aa0ae4197, looks like for some compiler issues with SFML, but we don't have that anymore, and this will give us some performance and size benefits.