### PR TITLE
Fix Lowercase Distro Names and Order

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ This is a personal project for fun and to experience emulating hardware and conn
 
 For linux, this project depends on `alsa` and `libudev`, you can install them using:
 ```sh
-# ubuntu/debian
+# Debian/Ubuntu
 sudo apt install libasound2-dev libudev-dev
-# arch
+# Arch
 sudo pacman -S alsa-lib systemd-libs
 ```
 


### PR DESCRIPTION
Made the Words Uppercase and make Debian the First because the package is .deb and Ubuntu is based off Debian