### PR TITLE
Add .deb install Instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ cargo install plastic
 cargo install plastic_tui
 ```
 
+
 Installation for Debian, Ubuntu, and Other Debian-Based Distributions
 
 Downloading and Installing the .deb Package
@@ -62,13 +63,18 @@ To install plastic from the .deb package:
 
 1. Download the .deb package:
 
+```
  curl -L -o plastic.deb https://github.com/silverhadch/plastic-debian-build/raw/master/plastic.deb
+```
 
 2. Install the package using dpkg:
 
+```
 sudo dpkg -i plastic.deb
+```
 
 This will install plastic along with any required dependencies on Debian-based systems.
+
 
 
 If you are using Arch Linux, `plastic` is available in the [official repositories](https://archlinux.org/packages/extra/x86_64/plastic/):

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ cargo install plastic_tui
 ```
 
 
+
 Installation for Debian, Ubuntu, and Other Debian-Based Distributions
 
 Downloading and Installing the .deb Package
@@ -74,6 +75,7 @@ sudo dpkg -i plastic.deb
 ```
 
 This will install plastic along with any required dependencies on Debian-based systems.
+
 
 
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ cargo install plastic_tui
 ```
 
 
-
+<br>
 Installation for Debian, Ubuntu, and Other Debian-Based Distributions
 
 Downloading and Installing the .deb Package
@@ -75,7 +75,7 @@ sudo dpkg -i plastic.deb
 ```
 
 This will install plastic along with any required dependencies on Debian-based systems.
-
+<br>
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ cargo install plastic
 cargo install plastic_tui
 ```
 
+Installation for Debian, Ubuntu, and Other Debian-Based Distributions
+
+Downloading and Installing the .deb Package
+
+To install plastic from the .deb package:
+
+1. Download the .deb package:
+
+ curl -L -o plastic.deb https://github.com/silverhadch/plastic-debian-build/raw/master/plastic.deb
+
+2. Install the package using dpkg:
+
+sudo dpkg -i plastic.deb
+
+This will install plastic along with any required dependencies on Debian-based systems.
+
+
 If you are using Arch Linux, `plastic` is available in the [official repositories](https://archlinux.org/packages/extra/x86_64/plastic/):
 
 ```


### PR DESCRIPTION
Until i get a Debian Mentor the Debian/Ubuntu package is in my repo with the build files for making a .debian package for plastic. When i get a Mentor/Sponsor that puts my .deb on the official repos i will change the install intructions.