### PR TITLE
Create plastic.desktop

### DIFF
--- a/plastic.desktop
+++ b/plastic.desktop
@@ -1,0 +1,11 @@
+#!/usr/bin/env xdg-open
+[Desktop Entry]
+Version=1.1
+Type=Application
+Name=Plastic - NES
+Comment=Plastic - NES Emulator
+# Icon path (for the icon in images/icon.png)
+Icon=/usr/share/icons/plastic-icon.png
+# Executable path for Plastic GUI
+Exec=/usr/bin/plastic
+Categories=Game;


### PR DESCRIPTION
Adding a default Desktop file which downstream can use. The Debian Package uses this already. And the Arch Mantainer wants a default in the repo first before using it. (The Desktop file for Arch will need no modifications since i made the deb exactly like the Arch one)