### PR TITLE
Fix: Add `plastic.desktop` file to release

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -91,8 +91,9 @@ jobs:
           Release ${{ github.ref_name }}
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
-          target/debian/*.deb
           LICENSE
+          package/plastic.dekstop
+          target/debian/*.deb
 
   windows:
     runs-on: windows-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,7 +92,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
           LICENSE
-          package/plastic.dekstop
+          package/plastic.desktop
           target/debian/*.deb
 
   windows:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -92,6 +92,7 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
         files: |
           LICENSE
+          docs/man/plastic.1
           package/plastic.desktop
           target/debian/*.deb
 


### PR DESCRIPTION
This PR adds `package/plastic.desktop` to the release to ensure it's available as a source in the `PKGBUILD`, following the discussion in [issue #31](https://github.com/Amjad50/plastic/issues/31#issuecomment-2439568358) about including the `.desktop` file and logo in the Arch packages.

CC: @orhun 