### PR TITLE
chore: add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "04:00"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
On macOS 26 (Tahoe / developer beta), the app crashes at startup due to an incompatibility between the system’s updated Objective-C type encodings and older winit/objc2 versions (panic during NSScreen enumeration).
To avoid being stuck on outdated crates and to pick up upstream fixes quickly, this PR adds Dependabot for automatic dependency updates.