### PR TITLE
Stabilize CI and clean up clippy warnings

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
@@ -13,9 +17,11 @@ env:
 jobs:
   linux:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v4
+
     - name: Download apt packages
       run: |
         sudo apt-get update -y && sudo apt-get install -y libasound2-dev libudev-dev
@@ -33,10 +39,7 @@ jobs:
     - name: Install cargo-deb
       run: cargo binstall cargo-deb -y
 
-    - name: Use sccache-cache
-      uses: mozilla-actions/sccache-action@v0.0.6
-
-    - uses: actions/checkout@v4
+    - uses: Swatinem/rust-cache@v2
 
     - name: Format check
       run: cargo fmt --all -- --check
@@ -50,16 +53,10 @@ jobs:
 
     - name: Build
       run: cargo build --verbose --all --all-targets --profile=ci
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-        RUSTC_WRAPPER: "sccache"
 
     # runs cargo with defaults flags, using the default `lcov` output
     - name: Test
       run: cargo llvm-cov --all-features --workspace --exclude plastic --exclude plastic_tui --lcov --output-path lcov.info
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-        RUSTC_WRAPPER: "sccache"
 
     # afterwards, upload the report to codecov
     - uses: codecov/codecov-action@v4
@@ -70,9 +67,6 @@ jobs:
 
     - name: Create Debian package
       run: cargo deb
-      env:
-        SCCACHE_GHA_ENABLED: "true"
-        RUSTC_WRAPPER: "sccache"
 
     - name: Upload debian package artifact
       if: github.ref == 'refs/heads/master'
@@ -98,18 +92,9 @@ jobs:
     runs-on: windows-latest
     
     steps:
-
-      - name: Use sccache-cache
-        uses: mozilla-actions/sccache-action@v0.0.6
       - uses: actions/checkout@v4
+      - uses: Swatinem/rust-cache@v2
       - name: Build
         run: cargo build --all --all-targets --profile=ci
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
       - name: Test
         run: cargo test --workspace --exclude plastic --exclude plastic_tui --lib
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
-

--- a/plastic_core/src/apu2a03/mod.rs
+++ b/plastic_core/src/apu2a03/mod.rs
@@ -356,7 +356,7 @@ impl APU2A03 {
                     self.request_interrupt_flag_change.set(true);
                 }
 
-                self.wait_reset = if self.cycle % 2 == 0 { 4 } else { 3 };
+                self.wait_reset = if self.cycle.is_multiple_of(2) { 4 } else { 3 };
             }
         }
     }
@@ -437,7 +437,7 @@ impl APU2A03 {
         // clocked on every CPU cycle
         self.triangle.timer_clock();
 
-        if self.cycle % 2 == 0 {
+        if self.cycle.is_multiple_of(2) {
             self.square_pulse_1.timer_clock();
             self.square_pulse_2.timer_clock();
             self.noise.timer_clock();

--- a/plastic_core/src/cartridge/error.rs
+++ b/plastic_core/src/cartridge/error.rs
@@ -62,10 +62,12 @@ impl From<ioError> for CartridgeError {
     }
 }
 
+#[derive(Default)]
 pub enum SramError {
     NoSramFileFound,
     SramFileSizeDoesNotMatch,
     FailedToSaveSramFile,
+    #[default]
     Others,
 }
 
@@ -103,11 +105,5 @@ impl Display for SramError {
 impl Debug for SramError {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmtResult {
         write!(f, "{}", self.get_message())
-    }
-}
-
-impl Default for SramError {
-    fn default() -> Self {
-        Self::Others
     }
 }

--- a/plastic_core/src/cartridge/mappers/mapper11.rs
+++ b/plastic_core/src/cartridge/mappers/mapper11.rs
@@ -41,7 +41,7 @@ impl Mapper11 {
 impl Mapper for Mapper11 {
     fn init(&mut self, prg_count: u8, is_chr_ram: bool, chr_count: u8, _sram_count: u8) {
         // even and positive
-        assert!(prg_count % 2 == 0 && prg_count > 0);
+        assert!(prg_count.is_multiple_of(2) && prg_count > 0);
 
         self.prg_count = prg_count / 2;
         self.chr_count = chr_count;

--- a/plastic_core/src/cartridge/mappers/mapper66.rs
+++ b/plastic_core/src/cartridge/mappers/mapper66.rs
@@ -52,7 +52,7 @@ impl Mapper66 {
 impl Mapper for Mapper66 {
     fn init(&mut self, prg_count: u8, is_chr_ram: bool, chr_count: u8, _sram_count: u8) {
         // even and more than 0
-        assert!(prg_count % 2 == 0 && prg_count > 0);
+        assert!(prg_count.is_multiple_of(2) && prg_count > 0);
 
         self.prg_count = prg_count / 2;
         self.chr_count = chr_count;

--- a/plastic_core/src/cartridge/mappers/mapper7.rs
+++ b/plastic_core/src/cartridge/mappers/mapper7.rs
@@ -31,7 +31,7 @@ impl Mapper7 {
 impl Mapper for Mapper7 {
     fn init(&mut self, prg_count: u8, is_chr_ram: bool, _chr_count: u8, _sram_count: u8) {
         // even and positive
-        assert!(prg_count % 2 == 0 && prg_count > 0);
+        assert!(prg_count.is_multiple_of(2) && prg_count > 0);
 
         self.prg_count = prg_count / 2;
         self.is_chr_ram = is_chr_ram;

--- a/plastic_core/src/ppu2c02/mod.rs
+++ b/plastic_core/src/ppu2c02/mod.rs
@@ -988,7 +988,7 @@ where
                 self.secondary_oam = [Sprite::filled_ff(); 8];
             }
             // fetch and reload shift registers
-            8..=256 if self.cycle % 8 == 0 => {
+            8..=256 if self.cycle.is_multiple_of(8) => {
                 self.reload_background_shift_registers();
 
                 if self.cycle != 256 {


### PR DESCRIPTION
This PR improves CI reliability and fixes remaining clippy warnings across the workspace.

### CI changes
- Replace `mozilla-actions/sccache-action` with `Swatinem/rust-cache` on Linux and Windows
- Switch the Linux job to `ubuntu-latest`
- Add `concurrency` to cancel in-progress runs on the same ref
- Move `actions/checkout@v4` to the top of the Linux job and simplify env usage

### Code changes
- Apply clippy suggestions in APU/PPU and mappers (use `is_multiple_of` instead of manual `% == 0`)
- Derive `Default` for `SramError` and mark `Others` as the default variant